### PR TITLE
tags: fix zero assignment on foreign keys

### DIFF
--- a/invenio_tags/api.py
+++ b/invenio_tags/api.py
@@ -151,7 +151,7 @@ def update_tag_of_user(uid, tag_name, dictionary_to_update):
         raise tags_errors.TagOwnerError(
             "The tag's owner id does not match the given id")
     # initialize variables to default values
-    usergroup_id = 0
+    usergroup_id = None
     group_rights = WtgTAG.ACCESS_LEVELS['View']
     show_in_description = True
     # get the values that user uploaded

--- a/invenio_tags/models.py
+++ b/invenio_tags/models.py
@@ -19,22 +19,21 @@
 
 """WebTag database models."""
 
+import re
+
+from datetime import date, datetime
+
 from six import iteritems
 
-# Database
+from invenio.base.globals import cfg
 from invenio.ext.sqlalchemy import db
+from invenio.modules.accounts.models import User, Usergroup
+from invenio.modules.records.models import Record as Bibrec
+from invenio.utils.text import wash_for_xml
+
 from sqlalchemy.ext.associationproxy import association_proxy
 
-# Related models
-from invenio.modules.records.models import Record as Bibrec
-from invenio.modules.accounts.models import User, Usergroup
-
-# Functions
-from invenio.base.globals import cfg
 from werkzeug import cached_property
-from invenio.utils.text import wash_for_xml
-from datetime import datetime, date
-import re
 
 
 class Serializable(object):
@@ -134,7 +133,7 @@ class WtgTAG(db.Model, Serializable):
     # Owner
     id_user = db.Column(db.Integer(15, unsigned=True),
                         db.ForeignKey(User.id),
-                        server_default='0')
+                        nullable=True)
 
     # Access rights of owner
     user_access_rights = db.Column(db.Integer(2, unsigned=True),
@@ -142,11 +141,11 @@ class WtgTAG(db.Model, Serializable):
                                    default=ACCESS_OWNER_DEFAULT)
 
     # Group
-    # equal to 0 for private tags
+    # equal to NULL for private tags
     id_usergroup = db.Column(
         db.Integer(15, unsigned=True),
         db.ForeignKey(Usergroup.id),
-        server_default='0')
+        nullable=True)
 
     # Group access rights
     group_access_rights = db.Column(

--- a/invenio_tags/upgrades/tags_2015_06_05_id_usergroup_nullable_on_tags.py
+++ b/invenio_tags/upgrades/tags_2015_06_05_id_usergroup_nullable_on_tags.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Upgrade recipe."""
+
+from invenio.ext.sqlalchemy import db
+from invenio.modules.upgrader.api import op
+
+
+depends_on = [u'tags_2014_08_22_initial']
+
+
+def info():
+    """Info message."""
+    return "Set id_usergroup nullable on table wtgTAG."
+
+
+def do_upgrade():
+    """Implement your upgrades here."""
+    with op.batch_alter_table("wtgTAG") as batch_op:
+        batch_op.alter_column(
+            column_name='id_usergroup',
+            type_=db.Integer(15, unsigned=True),
+            nullable=True
+        )
+        batch_op.alter_column(
+            column_name='id_user',
+            type_=db.Integer(15, unsigned=True),
+            nullable=True
+        )
+
+
+def estimate():
+    """Estimate running time of upgrade in seconds (optional)."""
+    return 1
+
+
+def pre_upgrade():
+    """Run pre-upgrade checks (optional)."""
+    pass
+
+
+def post_upgrade():
+    """Run post-upgrade checks (optional)."""
+    pass

--- a/tests/test_tags_restful.py
+++ b/tests/test_tags_restful.py
@@ -23,7 +23,6 @@ from __future__ import print_function, unicode_literals
 
 from collections import OrderedDict
 from datetime import datetime
-from dateutil.tz import tzutc
 
 from invenio.base.wrappers import lazy_import
 from invenio.ext.restful import validation_errors
@@ -40,6 +39,7 @@ class TestTagsRestfulAPI(APITestCase):
 
     @property
     def config(self):
+        """Config."""
         cfg = super(TestTagsRestfulAPI, self).config
         cfg['PACKAGES'] = [
             'invenio.base',
@@ -66,13 +66,8 @@ class TestTagsRestfulAPI(APITestCase):
 
     def tearDown(self):
         """Run after every test."""
-        from invenio.modules.accounts.models import User
-
         self.remove_oauth_token()
-        User.query.filter(User.nickname.in_([
-            self.user_a.nickname,
-        ])).delete(synchronize_session=False)
-        db.session.commit()
+        self.delete_objects([self.user_a])
 
     def test_405_methods_tagslistresource(self):
         """Test methods that return 405."""
@@ -514,7 +509,7 @@ class TestTagsRestfulAPI(APITestCase):
                 sorted(tag_representation.items(), key=lambda t: t[0])
             )
             ordered_created_tags.append(ordered_tag_repr)
-        #now query DB
+        # now query DB
         get_answer = self.get(
             'recordlisttagresource',
             user_id=self.user_a.id,


### PR DESCRIPTION
* Removes default value and sets nullable on usergroup id and user id
  column on tag table.
  (addresses inveniosoftware/invenio#3218)
  (closes inveniosoftware/invenio#3247) (closes #3)

* Fixes testsuite to properly clean the database after ending.

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>