### PR TITLE
global: package name standardisation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ with open(os.path.join("invenio_tags", "version.py"), "rt") as fp:
     version = g["__version__"]
 
 setup(
-    name='Invenio Tags',
+    name='invenio-tags',
     version=version,
     description=__doc__,
     long_description=readme + '\n\n' + history,


### PR DESCRIPTION
* Standardises package name in setup.py (`invenio-tags`) following the
  usual Invenio practices.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>