### PR TITLE
global: fix import of invenio_upgrader

### DIFF
--- a/invenio_tags/upgrades/tags_2014_08_22_initial.py
+++ b/invenio_tags/upgrades/tags_2014_08_22_initial.py
@@ -20,7 +20,7 @@
 import warnings
 import sqlalchemy as sa
 from sqlalchemy.dialects import mysql
-from invenio.modules.upgrader.api import op
+from invenio_upgrader.api import op
 
 depends_on = []
 

--- a/invenio_tags/upgrades/tags_2015_06_05_id_usergroup_nullable_on_tags.py
+++ b/invenio_tags/upgrades/tags_2015_06_05_id_usergroup_nullable_on_tags.py
@@ -20,7 +20,7 @@
 """Upgrade recipe."""
 
 from invenio.ext.sqlalchemy import db
-from invenio.modules.upgrader.api import op
+from invenio_upgrader.api import op
 
 
 depends_on = [u'tags_2014_08_22_initial']

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ history = open('CHANGES.rst').read()
 requirements = [
     'Flask',
     'six',
+    'invenio-upgrader>=0.1.0',
     'Invenio',
 ]
 


### PR DESCRIPTION
* FIX Fixes import of invenio_upgrader in the past upgrade recipes
  following its separation into standalone package.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>