### PR TITLE
tests: fix incompatibility with pytest>=2.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ python:
 
 before_install:
   - "travis_retry pip install --upgrade pip"
-  - "travis_retry pip install mock twine wheel coveralls"
+  - "travis_retry pip install check-manifest mock twine wheel coveralls"
   - "python requirements.py --extras=$REXTRAS --level=min > .travis-lowest-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=pypi > .travis-release-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=dev > .travis-devel-requirements.txt"
@@ -61,6 +61,7 @@ before_script:
   - "inveniomanage database create --quiet"
 
 script:
+  - "check-manifest --ignore .travis-\\*-requirements.txt"
   - "sphinx-build -qnN docs docs/_build/html"
   - "python setup.py test"
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,6 +20,6 @@
 # or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --clearcache --pep8 --ignore=docs --cov=invenio_tags --cov-report=term-missing
+addopts = --pep8 --ignore=docs --cov=invenio_tags --cov-report=term-missing
 pep8ignore =
     tests/* ALL

--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,9 @@ requirements = [
 
 test_requirements = [
     'Flask-Testing>=0.4.2',
-    'coverage>=3.7.1',
-    'pytest>=2.6.1',
-    'pytest-cov>=1.8.0',
+    'coverage>=4.0.0',
+    'pytest>=2.8.0',
+    'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
 ]
 
@@ -75,9 +75,6 @@ class PyTest(TestCommand):
     def run_tests(self):
         # import here, cause outside the eggs aren't loaded
         import pytest
-        import _pytest.config
-        pm = _pytest.config.get_plugin_manager()
-        pm.consider_setuptools_entrypoints()
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 


### PR DESCRIPTION
* FIX Removes calls to PluginManager
  consider_setuptools_entrypoints() removed in PyTest 2.8.0.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>